### PR TITLE
docs: design plan + implementation plan for feature-pattern & styling refactor

### DIFF
--- a/docs/refactor/design-plan.md
+++ b/docs/refactor/design-plan.md
@@ -1,0 +1,105 @@
+# Design Plan — Cinefix UI Redesign
+
+Scope: redesign the visual layout/content of every page and shared component, using **only Tailwind CSS + Ant Design (antd)** as styling technology. The custom SCSS system (`src/assets/scss/**`) is retired entirely — no new `.scss`/`.css` files, no hand-rolled selectors. This document defines the design direction and content structure; see `implementation-plan.md` for the execution steps.
+
+## 1. Design principles
+
+1. **One token source.** Colors, radii, and font scale are defined once and shared by both Tailwind (`tailwind.config.js`) and antd (`ConfigProvider theme.token`). No component should hardcode a hex value.
+2. **antd for structure & interaction, Tailwind for layout & spacing.** Use antd components (`Card`, `Tabs`, `Form`, `Button`, `Drawer`, `Skeleton`, `Carousel`, `Tag`, `Modal`, `Empty`) for anything with behavior/state. Use Tailwind utility classes for flex/grid layout, spacing, and responsive breakpoints around them.
+3. **Consistency over novelty.** Login/Register currently hand-roll raw `<input>`/`<button>` with ad-hoc gradients; Header does the same for its mobile toggle. All of that becomes antd `Form`/`Input`/`Button`/`Drawer` so the whole app looks like one product, not four different tutorials stitched together.
+4. **No visual regression in data — only in presentation.** Every field, action, and piece of data currently shown must still be shown (nothing removed), just re-laid-out and re-skinned.
+
+## 2. Design tokens
+
+Cinema/streaming-style dark theme with a warm accent (reads as "cinematic" without becoming a literal red/gold cliché).
+
+| Token | Value | Used as |
+|---|---|---|
+| `background` (base) | `#0B0D12` | page background |
+| `surface` | `#151822` | cards, header, footer, antd `Card`/`Modal` bg |
+| `surface-hover` | `#1D2130` | hover state on surface elements |
+| `border` | `#262B3A` | dividers, card borders |
+| `primary` (accent) | `#F2545B` (warm coral-red) | primary buttons, active tab indicator, links, price highlight |
+| `primary-hover` | `#FF6B72` | hover/active |
+| `secondary` (accent 2) | `#FFC857` (amber) | ratings, "hot"/"new" badges, star icon |
+| `text-primary` | `#F5F6FA` | headings, primary text |
+| `text-secondary` | `#9AA0B4` | secondary text, meta info |
+| `success` | antd default green | booking confirmed |
+| `danger` | antd default red (distinct from `primary`) | errors, sold-out seat |
+| radius | `10px` (cards), `8px` (buttons/inputs) | `rounded-xl` / `rounded-lg` in Tailwind, matching antd `borderRadius` token |
+| font | `Inter` (or keep current `Roboto` if already loaded) for UI text; no separate display font | headings + body, weight 600/700 for headings |
+| spacing scale | Tailwind default (4px base) | all layout spacing |
+| container | `max-w-screen-xl mx-auto px-4 md:px-6` | consistent page gutter, replaces one-off `max-w-*` per page |
+
+Implementation note: set these once in `tailwind.config.js` (`theme.extend.colors`) **and** in an antd `ConfigProvider theme={{ token: {...} }}` wrapper at the app root (`src/index.tsx` or `App.tsx`), pulling from the same constants object so they can never drift apart.
+
+## 3. Global layout
+
+### Header (sticky)
+- Sticky top bar, `surface` background, subtle bottom border, backdrop-blur on scroll.
+- Left: logo/wordmark ("Cinefix"). Center/right: nav links (Home, currently-fake "Contact"/"New" links should either get real destinations or be dropped — flag as an open question, don't invent fake pages).
+- Right-aligned auth area: if logged in, avatar + name + `Button` (text/danger) "Đăng xuất"; if not, `Button` (default) "Đăng nhập" + `Button` (primary) "Đăng ký".
+- Mobile: replace the hand-rolled hamburger + conditional `block/hidden` div with antd `Drawer` (right-side slide-in) triggered by a `MenuOutlined` icon button. Same nav content, stacked vertically.
+
+### Footer
+- Currently a single centered line. Expand slightly for a more finished feel while staying simple: 3-column layout on `md+` (brand blurb / quick links / copyright), collapsing to stacked centered text on mobile. Still no real social/contact data exists in the codebase — don't fabricate links, keep it minimal (brand + copyright + the existing nav links reused).
+
+### Page shell
+- Every route renders inside `max-w-screen-xl mx-auto px-4 md:px-6` content width except the Home hero/carousel, which can go full-bleed (`w-full`) above that constraint.
+- Loading: keep `LoadingNew` for route-level Suspense fallback, but re-skin it as a centered antd `Spin` (size large) with the brand accent color instead of the current custom CSS animation — removes the last consumer of hand-rolled loading CSS.
+- Empty/error states: introduce antd `Empty` for "no data" cases (e.g. film list empty, cinema list empty) — today these just silently render nothing.
+
+## 4. Per-page redesign
+
+### 4.1 Home (`/`, `/home`)
+Current: 3 independently-lazy-loaded sections stacked with no visual separation (Carousel → Film list → Cinema list).
+
+Redesign as three clearly delineated sections inside the page shell:
+
+1. **Hero banner** — keep `antd Carousel` (autoplay) but make it full-bleed with a gradient overlay (`bg-gradient-to-t from-background/90 to-transparent`) at the bottom so future banner text/CTA is legible if content team adds it later. Dots restyled to `primary` color instead of default. Skeleton state: full-width shimmer block (`SkeletonCarousel`, re-skinned with Tailwind + antd `Skeleton.Image`, no custom CSS).
+2. **"Phim đang chiếu" (Now showing)** — section header (`h2` + optional "Xem tất cả" link, even if it doesn't navigate anywhere useful yet — flag as open question), then the existing `react-slick` film carousel restyled: each `FilmItem` becomes an antd `Card` (`hoverable`, cover image, meta) instead of a raw `<img>` inside a slick slide, laid out via Tailwind grid gap. Loading: antd `Skeleton` cards matching the film-card shape (already exists as `SkeletonCard`, just restyle).
+3. **"Hệ thống rạp chiếu" (Cinemas)** — the current nested `Tabs` (chain → cluster → showtimes as `Tag`s) is functionally fine; restyle: outer `Tabs` `type="card"`, cluster sub-tabs as pill buttons, showtime `Tag`s become small antd `Button` (`type="dashed"`) chips grouped by date so users can scan by day instead of a flat tag wall.
+
+### 4.2 Film Detail (`/detail/:id`)
+Current: a single narrow `antd Card` (poster + name + play-trailer icon) floated left with an empty `<div>` next to it, then showtimes tabs below.
+
+Redesign:
+- **Hero section**: full-width backdrop using the film's own poster (blurred/darkened, `bg-cover` + overlay) as background, with the sharp poster (antd `Image`, supports zoom-on-click, replacing the current plain `<img>`) on the left and film info on the right — title, a "▶ Xem trailer" `Button` (primary) that opens the trailer in an antd `Modal`/embedded iframe instead of `window.open`, and any available metadata (currently only `tenPhim`/`hinhAnh`/`trailer` are used — don't invent fields that aren't in `FilmDetail`, but do surface all fields it actually has, e.g. rating/description if present in the type).
+- **Showtimes section** below the hero, same chain→cluster→showtime `Tabs` pattern as Home's cinema section for visual consistency, grouped by date.
+- Remove the current stray empty `<div></div>` next to the poster card — it's dead layout filler.
+
+### 4.3 Booking (`/booking/:maLichChieu`)
+Current state: **this page has no real UI** — it only dispatches a fetch and renders the literal text `BookingTicket`. This is net-new design, not a re-skin. The saga already fetches a "danh sách phòng vé" (seat map) via `GET_TICKET_API`.
+
+Proposed layout (two-column on desktop, stacked on mobile):
+- **Left/main column**: showtime summary bar (film name, cinema, room, date/time — from the fetched booking detail) as a `Card`, then the seat map: a `Card` containing a CSS-grid (Tailwind `grid`) of seat buttons, color-coded by state (available = `surface`, selected = `primary`, sold = `text-secondary`/disabled, VIP tier = `secondary` border) with a small legend row above the grid.
+- **Right column (sticky on desktop, bottom sheet on mobile)**: booking summary `Card` — selected seats list, per-seat price, total price, and a primary `Button` "Xác nhận đặt vé" (disabled until ≥1 seat selected).
+- Since seat-type/price/sold-state fields aren't modeled yet in `Redux/types/BookingTicketType.ts`, the implementation plan must extend that type and the reducer to hold `selectedSeats` — this is a real feature addition, not just styling, and should be scoped/estimated separately from the pure re-skin work.
+
+### 4.4 Auth — Login (`/login`) & Register (`/register`)
+Current: two different one-off layouts (split-screen with a random Unsplash image vs. a centered violet card), both with raw `<input>`.
+
+Redesign: **unify into one shared auth layout** (`AuthLayout`) used by both — split-screen on `lg+` (branding/art panel left using a real static asset instead of `source.unsplash.com/random`, which is non-deterministic and shouldn't ship to prod; use a poster collage or solid brand-gradient panel instead), centered card-only on mobile. Inside the card:
+- Migrate every field to antd `Form` + `Form.Item` + `Input`/`Input.Password` + `Button` (primary, block). This also means validation moves from `formik` + `yup` to antd `Form`'s built-in `rules` — see the recommendation in `implementation-plan.md` (optional but recommended for full antd consistency).
+- Login fields: `taiKhoan`, `matKhau` (unchanged). Register fields: `taiKhoan`, `matKhau`, `email`, `soDt`, `hoTen` (unchanged; `maNhom` stays a hidden constant, not a visible field, as it is today).
+- Footer link ("Need an account?" / "Already have an account?") styled the same way in both, using antd `Typography.Link`.
+
+## 5. Responsive breakpoints
+Use Tailwind's default breakpoints (`sm`/`md`/`lg`/`xl`) exclusively — retire the custom `450px` (`$bp-mobile`) SCSS breakpoint. Anywhere the old SCSS used a bespoke breakpoint, round to the nearest Tailwind default (`sm: 640px` is the closest match for the current mobile carousel behavior).
+
+## 6. Component inventory (antd replacing hand-rolled HTML)
+
+| Old | New |
+|---|---|
+| raw `<input>`/`<button>` (Login/Register) | antd `Form.Item` + `Input`/`Input.Password` + `Button` |
+| hand-rolled hamburger + `block/hidden` div (Header) | antd `Drawer` + `MenuOutlined` |
+| custom `_loadingNew.scss` spinner | antd `Spin` |
+| plain `<img>` for poster (Detail) | antd `Image` |
+| `window.open` for trailer | antd `Modal` with embedded video |
+| nothing (Booking page) | antd `Card`, `Button`, `Empty`, `Skeleton` for the new seat-map UI |
+
+## 7. Open questions for the product owner (don't guess these — ask before the executing agent invents content)
+- Header's "Contact" / "New" links currently point nowhere (`to="/"`) — real destinations, or remove them?
+- Should the Home "Xem tất cả" (see all) link on the film section go anywhere (e.g. a future `/films` listing page), or omit it for now?
+- Is there a real logo asset to replace `./img/Movie.png` / the Unsplash placeholder on the auth screen, or should this plan ship with a generated placeholder?
+- Seat pricing/tier rules for the Booking page — is this data already returned by `LayDanhSachPhongVe`, or does it need a separate lookup? (implementation plan assumes it's in the existing response; confirm against the real API shape before building the seat grid.)

--- a/docs/refactor/implementation-plan.md
+++ b/docs/refactor/implementation-plan.md
@@ -1,0 +1,154 @@
+# Implementation Plan — Feature-Pattern Refactor + Tailwind/antd-only Styling
+
+Companion to `design-plan.md`. This document is written to be handed to an execution agent (or a human) with no other context beyond this repo. Two independent-but-sequenced workstreams:
+
+- **A. Structural refactor**: page-pattern → feature-pattern folders.
+- **B. Styling refactor**: retire the custom SCSS system, migrate everything to Tailwind + antd per `design-plan.md`, including the net-new Booking page UI.
+
+**Do A before B.** B rewrites JSX/markup extensively; doing it against files that are about to move would double the diff/conflict surface. Within each stage, verify (`CI=true pnpm build` + `pnpm test`) and commit before moving to the next phase — every phase must leave the app in a working, deployable state.
+
+---
+
+## A. Structural refactor: feature-pattern
+
+### A.0 Target structure
+
+```
+src/
+  app/                      # composition root
+    App.tsx
+    store.ts                # was Redux/store.ts
+    routes.tsx              # was Routes/AppRoute.tsx + constants/initialRoute.ts merged
+    rootSaga.ts             # was Redux/saga/rootSaga.ts
+  features/
+    home/
+      components/           # CarouselHome, Film, FilmItem, ListCinema, ListMovie
+      redux/                 # banner + cinema + filmList: constants, reducer, saga, types (one sub-per-domain or grouped — see A.2)
+      pages/Home.tsx
+      index.ts               # public barrel: only what routes.tsx needs (the page)
+    film-detail/
+      pages/Detail.tsx
+      services/              # FlimDetailService, ManagementMovieService (confirm both are detail-only — see A.1 verification step)
+      redux/types/           # FilmDetail, CalendarFilmType (no redux state today, just types — keep as-is unless Booking work below changes that)
+      index.ts
+    booking/
+      pages/BookingTicket.tsx
+      redux/                 # BookingTicketConstants, BookingTicket.reducer, Booking.saga, BookingTicketType
+      index.ts
+    auth/
+      components/AuthLayout.tsx        # new shared layout, see design-plan §4.4
+      pages/Login.tsx
+      pages/Register.tsx
+      validation/                       # both ValidationSchema files, unify naming casing
+      redux/                            # UserConstants, UserSaga.reducer, UserSaga(+test), UserType
+      services/Auth.services.ts
+      index.ts
+  shared/
+    components/               # Header, Footer, LoadingNew, SkeletonCard, SkeletonCarousel, Star
+    templates/                 # HomeTemplate, ErrorTemplate
+    redux/
+      loading/                 # Loading.reducer.ts (cross-feature UI state)
+    types/                     # IRoutes, ITemplate
+    utils/                     # common.ts(+test), setting.ts
+  assets/                      # img/ only after stage B removes scss/
+  index.tsx
+  index.css                    # only if design-plan review keeps it; otherwise deleted in stage B
+  react-app-env.d.ts
+  reportWebVitals.ts
+  setupTests.ts
+  __mocks__/
+```
+
+Each `features/<name>/index.ts` re-exports only what `app/routes.tsx` needs (the page component) — internal feature modules import each other by relative path, not through the barrel, to avoid circular-import foot-guns.
+
+### A.1 Pre-flight verification (do this before moving anything)
+
+Some current file placements are ambiguous and must be confirmed by grep, not assumed:
+- `services/ManagementMovieService.ts` — confirm it's only imported by `Pages/Details/Detail.tsx`. If any other feature imports it, it belongs in `shared/` instead of `features/film-detail/`.
+- `constants/BookingTicket.ts`, `constants/FilmList.ts`, `constants/ListCinema.ts`, `constants/banner.ts` — confirm each is only imported by its matching reducer (this was true as of the last audit; re-verify since files may have moved since).
+- `Redux/reducer/Loading.reducer.ts` — confirm it's referenced from `Redux/store.ts` and read by more than one feature (Home + Film both read `state.Loading`) — this is why it's `shared/`, not feature-owned.
+
+### A.2 Redux slice grouping for `features/home`
+
+Home currently pulls from **three** independent Redux domains (banner, cinema, filmList) that don't share reducers/sagas today. Two acceptable approaches — pick one and apply consistently, don't mix:
+1. Keep them as three sub-folders under `features/home/redux/{banner,cinema,filmList}/` (lowest-risk, mirrors current separation).
+2. Consolidate into one `homeSlice`-per-concern file each, still separate saga watchers registered in `app/rootSaga.ts`.
+
+Recommendation: **option 1** for this pass — don't couple unrelated data (banners, cinema list, film list) into a shared reducer just for the sake of fewer files; that's a premature abstraction the design/plan doesn't require.
+
+### A.3 Migration mechanics
+1. `git mv` each file/folder to its new home (preserves history — don't recreate files with Write).
+2. Update every import path repo-wide. Because `tsconfig.json` sets `baseUrl: "src"`, absolute imports like `Redux/store`, `Components`, `services/...`, `constants/...`, `util/...`, `Template` are used everywhere — grep for each old root segment (`Redux/`, `Components/`, `Pages/`, `Routes/`, `Template/`, `services/`, `constants/`, `util/`, `types/`) across `src/**/*.ts(x)` and rewrite to the new absolute path (e.g. `Redux/store` → `app/store`, `Components` → `shared/components`, `util/common` → `shared/utils/common`).
+3. Update the two existing test files' relative imports if their target moved (`src/Redux/saga/BannerSaga/BannerSaga.test.ts`, `src/Redux/saga/UserSaga/UserSaga.test.ts`) — they currently import relatively from their own folder, so this only matters if the saga file's *neighbors* change.
+4. Update `jest.config.js`'s `moduleNameMapper` only if `src/__mocks__` moves (plan above keeps it at `src/__mocks__`, so likely no change needed) — verify path still resolves.
+5. `craco.config.js` has no hardcoded `src` file paths — no change expected, but re-run the build to confirm the swc-loader/eslint-webpack-plugin config still applies (it targets by file extension, not path, so it should be unaffected).
+6. Delete now-empty old directories (`Pages/`, `Routes/`, `Template/` at top level, old `Redux/` if fully absorbed, old `constants/`, `services/` if fully absorbed, `types/` if fully absorbed).
+
+### A.4 Verification gate for stage A
+- `rm -rf build && CI=true pnpm build` → must print "Compiled successfully." (no unresolved-import errors, no new eslint warnings).
+- `pnpm test` → same 3 suites / 7 tests must still pass, from their new locations.
+- `pnpm exec tsc --noEmit` clean.
+- Manually diff `git diff --stat` against pre-refactor to confirm no file content changed unintentionally during the move (only import-path lines should differ, aside from any files intentionally merged like `routes.tsx`).
+
+---
+
+## B. Styling refactor: Tailwind + antd only
+
+Do this **after** A is merged, operating on the new feature-based paths.
+
+### B.0 Token setup (do first, once)
+1. Create a single source of truth for design tokens, e.g. `src/shared/theme/tokens.ts`, exporting the palette from `design-plan.md` §2 as plain constants.
+2. Wire it into `tailwind.config.js` (`theme.extend.colors`) by importing the same constants (a `.js`/`.cjs` config can `require()` a `.ts` file only via `ts-node`/build step — simplest is to keep the raw hex values duplicated in both `tailwind.config.js` and a small `tokens.ts`, with a comment in each pointing at the other, OR define the palette in a `.js` tokens file that both `tailwind.config.js` and the antd `ConfigProvider` import — prefer this second option since it avoids the TS-in-CJS friction and gives an actual single source of truth).
+3. Wrap the app root (`src/App.tsx` or `src/index.tsx`) in antd's `<ConfigProvider theme={{ token: { colorPrimary: tokens.primary, colorBgBase: tokens.background, borderRadius: 8, ... } }}>`.
+4. `pnpm build` and eyeball that antd defaults (buttons, tabs) already pick up the new primary color before touching any individual page — this de-risks the rest of the migration.
+
+### B.1 Retire the SCSS system
+1. Inventory every remaining selector in `src/assets/scss/**` against the components that use them (post stage-A move) — for each, either (a) port to Tailwind utility classes on the element, or (b) if it's a genuinely reusable pattern (e.g. the sticky-footer flex trick currently in `index.css`), express it as a small reusable Tailwind class combo or a `@apply`-based utility in `src/index.css` kept minimal, or a tiny reusable React wrapper component — prefer plain Tailwind classes over `@apply` where practical, since `@apply` is exactly the kind of "custom CSS layer" this migration is trying to eliminate.
+2. Delete `src/assets/scss/` entirely once every selector is accounted for.
+3. Remove `sass` and `sass-loader` from `package.json` devDependencies/dependencies and re-run `pnpm install` to update the lockfile.
+4. Remove the `import "assets/scss/style.scss"` line from `src/index.tsx`.
+5. Re-check `src/index.css` per design-plan — likely reduced to a handful of Tailwind `@layer base`/`@apply` rules for the sticky-footer layout, or removed if that layout is achieved with plain flex/grid utility classes instead (preferred).
+
+### B.2 Per-page rebuild (in this order, easiest→hardest, matching `design-plan.md` §4)
+1. **Shared shell**: `Header`, `Footer`, `LoadingNew` (→ antd `Spin`), `ErrorTemplate`, `HomeTemplate`.
+2. **Home**: hero carousel, film cards (`FilmItem` → antd `Card`), cinema tabs restyle.
+3. **Auth**: build the shared `AuthLayout`, migrate `Login`/`Register` to antd `Form`.
+4. **Film Detail**: hero section, showtime tabs.
+5. **Booking**: this is the only page needing *new* functionality, not just re-skinning:
+   - Extend `features/booking/redux/BookingTicketType.ts` with the seat-map shape actually returned by `GET_TICKET_API` (`/api/QuanLyDatVe/LayDanhSachPhongVe`) — inspect the real API response shape first (don't guess field names), then model `selectedSeats: string[]` (or seat IDs) in the reducer plus `SELECT_SEAT`/`DESELECT_SEAT` action types (client-side only, no new saga needed unless a submit-booking endpoint also needs wiring — check whether the CyberSoft training API this project targets has a "đặt vé" submit endpoint; if yes, wire a new saga watcher for it under `features/booking/redux/`).
+   - Build the seat-grid + summary UI per `design-plan.md` §4.3.
+
+### B.3 Recommended (optional) follow-on: drop formik+yup for antd Form validation
+`Login`/`Register` currently use `formik` + `yup`. Once both are rebuilt with antd `Form`, antd's own `rules`-based validation covers the same cases (required, email format, min length) without a second form-state library. This is optional — flag it as a separate decision point, don't bundle it silently into the styling PR, since it's a dependency removal with its own blast radius (check no other page uses `formik`/`yup` before removing — as of this writing, only `Login`/`Register`/their validation-schema files do).
+
+### B.4 Verification gate for stage B
+- `rm -rf build && CI=true pnpm build` → "Compiled successfully."
+- `pnpm test` → still green (note: Booking's new Redux logic should get new unit tests added here, matching the existing saga-test pattern in `BannerSaga.test.ts`/`UserSaga.test.ts` — coverage config in `jest.config.js` requires 100% branches/functions/lines/statements when run with `--coverage`, so new code must be tested, not just built).
+- No `.scss` files remain anywhere in `src/`; `sass`/`sass-loader` are gone from `package.json`.
+- Bundle size check: `build/bundle-report.html` should show no regression vs. the pre-refactor baseline (antd was already the largest dependency pre-refactor — this pass shouldn't add new heavy libraries; specifically don't add a second UI kit or a CSS-in-JS runtime, which would contradict "Tailwind + antd only").
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Import-path rewrite misses a file, breaks build | Rely on `CI=true pnpm build` (fails loudly on unresolved modules) after every phase, not just at the end |
+| Booking page scope creep (it's a real feature build, not a re-skin) | Time-box it separately from the rest of stage B; if the real submit-booking API isn't confirmed, ship the seat-selection UI with a stubbed/disabled submit and flag it explicitly rather than guessing an endpoint |
+| antd `ConfigProvider` token names don't map 1:1 to every component's default styling | Verify visually (or via the built CSS) after B.0 before proceeding — don't assume token propagation, check it |
+| Removing `sass`/`formik`/`yup` breaks something not caught by the 7 existing tests (coverage is real but narrow — only 2 sagas + 1 util fn are tested) | Manual smoke-test checklist per page before merging stage B (see below), since automated coverage doesn't reach the UI layer at all today |
+
+## Manual smoke-test checklist (run after each stage, before merging)
+- [ ] Home loads: banner autoplays, film list scrolls, cinema tabs switch and show showtimes
+- [ ] Detail page loads for a real `maPhim`, trailer opens, showtimes tabs work, clicking a showtime navigates to `/booking/:maLichChieu`
+- [ ] Booking page loads for a real `maLichChieu`, seat grid renders, selecting seats updates the summary/total
+- [ ] Login: validation errors show, successful login updates Header (name + logout button)
+- [ ] Register: validation errors show, successful register redirects/behaves as today
+- [ ] Mobile viewport (< 640px): Header drawer opens/closes, all pages remain usable without horizontal scroll
+- [ ] 404 route still renders `ErrorTemplate`
+
+## Suggested ownership if split across multiple execution agents
+- **Agent 1**: Stage A only (structural move). Must finish and pass its verification gate before Stage B starts — Stage B agents should assume the target structure in A.0 already exists.
+- **Agent 2**: Stage B.0–B.1 (tokens + SCSS retirement) — foundational, blocks B.2.
+- **Agent 3**: Stage B.2 pages 1–4 (shell, Home, Auth, Detail) — mechanical re-skin, no new logic.
+- **Agent 4** (most senior/careful): Stage B.2 page 5 (Booking) — the only workstream involving new Redux state and unverified API shape; keep isolated from the others since it's the highest-uncertainty piece.


### PR DESCRIPTION
## Summary
Planning-only, no code changes — for hand-off to an execution agent.

- `docs/refactor/design-plan.md`: visual redesign direction for every page/section, using only Tailwind + antd (retiring the current SCSS system). Includes a shared design-token proposal, a component-swap inventory (raw HTML → antd), and open questions that need product-owner input before an executor invents content.
- `docs/refactor/implementation-plan.md`: two-stage execution plan — (A) migrate the current page-pattern folder layout to a feature-based structure (`src/features/{home,film-detail,booking,auth}`, `src/shared`, `src/app`), then (B) retire SCSS and rebuild each page's markup per the design plan. Includes a target folder tree, import-path migration mechanics, a risk register, a manual smoke-test checklist, and a suggested multi-agent ownership split.

Notably, the Booking page (`/booking/:maLichChieu`) currently has no real UI (`<div>BookingTicket</div>`) — the plan calls this out explicitly since it needs new design + new Redux state (seat selection), not just a re-skin.

## Test plan
- [x] N/A — docs only, no build/runtime changes